### PR TITLE
feat: add new interative thumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,6 @@ In some use case e.g. "tension rod", it's more convenient to use method instead 
 
 <img src="https://raw.githubusercontent.com/flyskywhy/react-native-smooth-slider/master/Screenshots/vertical_tension_rod.png" width="75">
 
-## Sponsor
-
-Alipay: flyskywhy@gmail.com
-
-ETH: 0xd02fa2738dcbba988904b5a9ef123f7a957dbb3e
-
 
 ---
 


### PR DESCRIPTION
### What does this PR do?
This PR add new interative thumbs to the slider

- add float thumb
- add goal thumb
- add current value to thumb
- add the following props
  - goalThumbStyle
  - thumbFloatStyle
  - showThumbValue
  - floatThumbOffset
  - onReady
  - thumbValueFormatter


### Screenshot
<img width="367" alt="Screenshot 2020-06-07 at 23 11 08" src="https://user-images.githubusercontent.com/36575414/83981260-3a410080-a914-11ea-8bc7-47a50791cf39.png">


![4486dq](https://user-images.githubusercontent.com/36575414/83981224-e33b2b80-a913-11ea-882a-f5a64e2846da.gif)

